### PR TITLE
#15 EmailHelper Edge Case Fix

### DIFF
--- a/src/webchatinterface/helpers/EmailHelper.java
+++ b/src/webchatinterface/helpers/EmailHelper.java
@@ -62,7 +62,7 @@ public class EmailHelper
         }
 
         //---Ensure Valid Character Lengths---//
-        if(localPartWithQuotedMarkers.length() + removedChars > 64)
+        if(localPartWithoutQuotedMarkers.length() + removedChars > 64)
             return false;
         if(localPartWithoutQuotedMarkers.length() == 0 && removedChars == 0)
             return false;

--- a/test/unit/EmailHelperTest.java
+++ b/test/unit/EmailHelperTest.java
@@ -42,7 +42,8 @@ public class EmailHelperTest
 		"email@domain.co.jp",
 		"email@(comment)domain.com",
 		"email@domain.com(comment)",
-		"firstname-lastname@domain.com"};
+		"firstname-lastname@domain.com",
+		"\"a\"1111111111111111111111111111111111111111111111111111111111111@test.com"};
 
 		String[] invalidEmailAddresses = {
 		"ABC.example.com",


### PR DESCRIPTION
Found that `localPartWithQuotedMarkers` was used when `localPartWithoutQuotedMarkers` was intended. The 'localPartWithoutQuotedMarkers' replaces any quoted text with `[QUOTED]`, but and when this happens, the length of the string was not valid in this line:

```
//---Ensure Valid Character Lengths---//
if(localPartWithoutQuotedMarkers.length() + removedChars > 64)
       return false;
```

This pull request fixes this issue and  adds better test coverage.