### PR TITLE
#18 Various Usage Monitor Fixes

### DIFF
--- a/src/webchatinterface/server/ui/WebChatServerGUI.java
+++ b/src/webchatinterface/server/ui/WebChatServerGUI.java
@@ -2,16 +2,16 @@ package webchatinterface.server.ui;
 
 import webchatinterface.AbstractIRC;
 import webchatinterface.server.network.ChannelManager;
+import webchatinterface.server.ui.components.ResourceMonitor;
 import webchatinterface.server.util.ResourceLoader;
 import webchatinterface.server.AbstractServer;
 import webchatinterface.server.communication.WebChatServer;
 import webchatinterface.server.communication.WebChatServerInstance;
 import webchatinterface.server.network.Channel;
 import webchatinterface.server.ui.components.ConsoleManager;
-import webchatinterface.server.ui.components.UsageMonitor;
 import webchatinterface.server.ui.dialog.AccountListDialog;
 import webchatinterface.server.ui.dialog.PreferencesDialog;
-import webchatinterface.server.util.UsageMonitorManager;
+import webchatinterface.server.util.ResourceMonitorManager;
 import webchatinterface.util.Command;
 
 import javax.swing.*;
@@ -47,7 +47,7 @@ public class WebChatServerGUI extends JFrame implements ActionListener, WindowLi
 	private JMenuItem aboutApp;
 	private JMenuItem getHelp;
 	private ConsoleManager consoleMng;
-	private UsageMonitorManager usageMonitorManager;
+	private ResourceMonitorManager resourceMonitorManager;
 	private boolean running = false;
 	private WebChatServer server;
 	
@@ -110,7 +110,8 @@ public class WebChatServerGUI extends JFrame implements ActionListener, WindowLi
 	private void buildUI()
 	{
 		this.consoleMng = ConsoleManager.getInstance();
-		this.usageMonitorManager = UsageMonitorManager.getInstance();
+		this.resourceMonitorManager = ResourceMonitorManager.getInstance();
+		this.resourceMonitorManager.start();
 		(new Thread(consoleMng)).start();
 		
 		//---BUILD MENU BAR---//
@@ -204,7 +205,7 @@ public class WebChatServerGUI extends JFrame implements ActionListener, WindowLi
 		{
 			this.running = false;
 			this.server.suspend();
-			this.usageMonitorManager.stop();
+			this.resourceMonitorManager.stop();
 			this.server = null;
 			
 			super.setTitle("Web Chat Server Interface - Suspended");
@@ -218,7 +219,7 @@ public class WebChatServerGUI extends JFrame implements ActionListener, WindowLi
 			//run server on specified port
 			this.running = true;
 			this.server = new WebChatServer();
-			this.usageMonitorManager.start(server);
+			this.resourceMonitorManager.start(server);
 			this.server.start();
 			
 			super.setTitle("Web Chat Server Interface - Running");
@@ -314,12 +315,12 @@ public class WebChatServerGUI extends JFrame implements ActionListener, WindowLi
 		//If Usage Monitor is Visible
 		if(show)
 		{
-			this.masterPane.add(UsageMonitor.getInstance(), BorderLayout.PAGE_END);
+			this.masterPane.add(ResourceMonitor.getInstance(), BorderLayout.PAGE_END);
 			this.masterPane.validate();
 		}
 		else
 		{
-			this.masterPane.remove(UsageMonitor.getInstance());
+			this.masterPane.remove(ResourceMonitor.getInstance());
 			this.masterPane.validate();
 		}
 	}

--- a/src/webchatinterface/server/ui/components/ResourceMonitor.java
+++ b/src/webchatinterface/server/ui/components/ResourceMonitor.java
@@ -7,14 +7,14 @@ import java.awt.*;
   *@version 1.4.3
   *@since 06/05/2016
   *<p>
-  *The UsageMonitor class extends the Java JPanel. It is responsible for
+  *The ResourceMonitor class extends the Java JPanel. It is responsible for
   *acquiring and displaying useful data with regards to the server application
   *memory allocations, processes, and server status.
   *<p>
-  *The implementing class can simply add the UsageMonitor object to the frame.
+  *The implementing class can simply add the ResourceMonitor object to the frame.
   */
 
-public class UsageMonitor extends JPanel
+public class ResourceMonitor extends JPanel
 {
 	private JLabel usedMem;
 	private JLabel freeMem;
@@ -32,7 +32,7 @@ public class UsageMonitor extends JPanel
 	private JProgressBar memUsage;
 	private JProgressBar serverUsage;
 	
-	private UsageMonitor()
+	private ResourceMonitor()
 	{
 		//Build Container Object
 		super();
@@ -212,7 +212,7 @@ public class UsageMonitor extends JPanel
 
 	public void changeServerUpTimeText(String text)
 	{
-		this.upTime.setText(text);
+		this.upTime.setText("Server Up Time: " + text);
 	}
 
 	public void changeAvailableProcessors(int availableProcessors)
@@ -220,13 +220,13 @@ public class UsageMonitor extends JPanel
 		this.availableProcessors.setText("Available Processors: " + availableProcessors);
 	}
 
-	public static UsageMonitor getInstance()
+	public static ResourceMonitor getInstance()
 	{
 		return InstanceHolder.INSTANCE;
 	}
 
 	private static class InstanceHolder
 	{
-		private static final UsageMonitor INSTANCE = new UsageMonitor();
+		private static final ResourceMonitor INSTANCE = new ResourceMonitor();
 	}
 }

--- a/src/webchatinterface/server/util/ResourceMonitorManager.java
+++ b/src/webchatinterface/server/util/ResourceMonitorManager.java
@@ -6,37 +6,42 @@ import webchatinterface.helpers.TimeHelper;
 import webchatinterface.server.AbstractServer;
 import webchatinterface.server.communication.WebChatServer;
 import webchatinterface.server.network.ChannelManager;
-import webchatinterface.server.ui.components.UsageMonitor;
+import webchatinterface.server.ui.components.ResourceMonitor;
 
 import java.awt.*;
 
-public class UsageMonitorManager implements Runnable
+public class ResourceMonitorManager implements Runnable
 {
 	private Runtime runtime;
 	private WebChatServer server;
 	private ChannelManager channelManager;
-	private UsageMonitor usageMonitorPanel;
+	private ResourceMonitor usageMonitorPanel;
 	private int serverUpTime;
 	private volatile boolean RUN;
 
-	public UsageMonitorManager()
+	public ResourceMonitorManager()
 	{
 		this.runtime = Runtime.getRuntime();
 		this.server = null;
 		this.channelManager = ChannelManager.getInstance();
-		this.usageMonitorPanel = UsageMonitor.getInstance();
+		this.usageMonitorPanel = ResourceMonitor.getInstance();
 		this.serverUpTime = 0;
 		this.RUN = false;
 	}
 
-	public void start(WebChatServer server)
+	public void start()
 	{
-		this.server = server;
 		if(this.RUN)
 			return;
 
 		(new Thread(this)).start();
 		this.RUN = true;
+	}
+
+	public void start(WebChatServer server)
+	{
+		this.server = server;
+		this.start();
 	}
 
 	public void stop()
@@ -186,13 +191,13 @@ public class UsageMonitorManager implements Runnable
 		return new Color(0,204,0);
 	}
 
-	public static UsageMonitorManager getInstance()
+	public static ResourceMonitorManager getInstance()
 	{
-		return UsageMonitorManager.InstanceHolder.INSTANCE;
+		return ResourceMonitorManager.InstanceHolder.INSTANCE;
 	}
 
 	private static class InstanceHolder
 	{
-		private static final UsageMonitorManager INSTANCE = new UsageMonitorManager();
+		private static final ResourceMonitorManager INSTANCE = new ResourceMonitorManager();
 	}
 }


### PR DESCRIPTION
- Noticed that when the server is initially suspended, the resource monitor up time text correctly displays a label. However, when the server is run, this label is no longer visible.
- The UsageMonitor thread should start upon running the application.
- The available processors text can display the total number of available processors while suspended. This value is taken from the runtime object.
- UsageMonitor should be renamed to ResourceMonitor.

This PR addresses all of these issues.